### PR TITLE
Keep clientId in local closure

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,8 +26,10 @@ app.get('/events/', function(req, res) {
     	'Connection': 'keep-alive'
     });
     res.write('\n');
-    clients[++clientId] = res;  // <- Add this client to those we consider "attached"
-    req.on("close", function(){delete clients[clientId]});  // <- Remove this client when he disconnects
+    (function(clientId) {
+        clients[clientId] = res;  // <- Add this client to those we consider "attached"
+        req.on("close", function(){delete clients[clientId]});  // <- Remove this client when he disconnects
+    })(++clientId)
 });
 
 setInterval(function(){


### PR DESCRIPTION
... so that the correct one will get deleted. Without that, its always the last clientId that gets deleted.
